### PR TITLE
fix(CLI): Address printing incorrect queue name

### DIFF
--- a/resolve_proxy_encoder/app/cli.py
+++ b/resolve_proxy_encoder/app/cli.py
@@ -100,24 +100,22 @@ def work(
 ):
     """Prompt to start Celery workers on local machine"""
 
-    print("\n")
-    console.rule(f"[green bold]Start workers[/] :construction_worker:", align="left")
-    print("\n")
-
-    # Print worker queue
-
-    ver_colour = "green" if settings["version_info"]["is_latest"] else "yellow"
-    print(
-        f"[cyan]Consuming from queue: [/][{ver_colour}]'{settings['version_info']['commit_short_sha']}'[/]"
-    )
-
     if not workers_to_launch:
         workers_to_launch = 0
 
+    print("\n")
+
     if workers_to_launch > 0:
-        print(f"[green]Starting workers! :construction_worker:[/]")
+        console.rule(
+            f"[green bold]Starting workers![/] :construction_worker:", align="left"
+        )
     else:
-        print(f"[cyan]Starting worker launcher prompt :construction_worker:[/]")
+        console.rule(
+            f"[green bold]Starting worker launcher prompt[/] :construction_worker:",
+            align="left",
+        )
+
+    print("\n")
 
     from ..worker import launch_workers
 

--- a/resolve_proxy_encoder/worker/launch_workers.py
+++ b/resolve_proxy_encoder/worker/launch_workers.py
@@ -171,7 +171,7 @@ def new_worker(id=None):
     )
 
 
-def launch_workers(workers_to_launch: int):
+def launch_workers(workers_to_launch: int, queue_name: str):
 
     # Start launching
 
@@ -186,17 +186,24 @@ def main(workers: int = 0):
     os_ = platform.system()
     cpu_cores = multiprocessing.cpu_count()
 
+    queue_name = get_queue()
+    if not queue_name:
+        raise TypeError("Couldn't get queue!")
+
+    print()
+    logger.info(f"[cyan]Consuming from queue: '{queue_name}'\n")
+
     # Don't bother with tips if not prompting
     if workers:
 
-        launch_workers(workers)
+        launch_workers(workers, queue_name)
 
     else:
 
         print(f"[green]Running on {os_} with {cpu_cores} cores.[/]\n")
         print("For maximum performance, start as many workers as CPU cores.")
         print("Default recommendation is 2 cores spare for Resolve and other tasks.\n")
-        launch_workers(prompt_worker_amount(cpu_cores))
+        launch_workers(prompt_worker_amount(cpu_cores), queue_name)
 
     print(f"[green]Done![/]")
     core.app_exit(0, 5)

--- a/resolve_proxy_encoder/worker/utils.py
+++ b/resolve_proxy_encoder/worker/utils.py
@@ -51,7 +51,7 @@ def get_queue():
 
         logger.warning(
             "[yellow]Version constrain is disabled!\n"
-            + "You [bold]must[/] ensure routing and version compatability yourself!"
+            "You [bold]must[/] ensure routing and version compatability yourself!"
         )
 
         return "celery"


### PR DESCRIPTION
Incorrect queue name reported by CLI `print_routing_key` function 
Fixes #108