### PR TITLE
fix(handlers): revert proxy status on link failed

### DIFF
--- a/resolve_proxy_encoder/queuer/handlers.py
+++ b/resolve_proxy_encoder/queuer/handlers.py
@@ -348,18 +348,20 @@ def handle_offline_proxies(media_list: list) -> list:
 
             if answer.lower().startswith("y"):
                 pprint(f"[yellow]Queuing '{offline_proxy['file_name']}' for re-render")
-                [
-                    x["proxy"].update("None")
-                    for x in media_list
-                    if x["file_path"] == offline_proxy["file_path"]
-                ]
+
+                for x in media_list:
+                    if x["file_path"] == offline_proxy["file_path"]:
+                        x["proxy"] = "None"
 
             elif answer.lower().startswith("a"):
 
                 pprint(
                     f"[yellow]Queuing {len(offline_proxies)} offline proxies for re-render"
                 )
-                [x["proxy"].update("None") for x in media_list if x == "Offline"]
+
+                for x in media_list:
+                    if x == "Offline":
+                        x["proxy"] = "None"
 
         global SOME_ACTION_TAKEN
         SOME_ACTION_TAKEN = True

--- a/resolve_proxy_encoder/queuer/link.py
+++ b/resolve_proxy_encoder/queuer/link.py
@@ -275,12 +275,19 @@ def link_proxies_with_mpi(media_list):
         if Confirm.ask(
             f"[yellow]{len(link_fail)} proxies failed to link. Would you like to re-render them?"
         ):
+            # Remove offline status, redefine media list
+            for x in media_list:
+                if x in link_fail:
+                    x["proxy"] = "None"
 
-            media_list = [
-                x for x in media_list if x not in link_success or x not in link_fail
-            ]
+            media_list = [x for x in media_list if x not in link_success]
 
-    media_list = [x for x in media_list if x not in link_success]
+    else:
+
+        # Queue only those that remain
+        media_list = [
+            x for x in media_list if x not in link_success or x not in link_fail
+        ]
 
     logger.debug(f"[magenta]Remaining unlinked media: {media_list}")
     return media_list


### PR DESCRIPTION
Offline proxies were getting caught both by 'existing-unlinked' handler
on link attempt and 'offline' handler when the proxy file existed, but was invalid.