### PR TITLE
fix: Remove linked proxies from queue

### DIFF
--- a/resolve_proxy_encoder/queuer/link.py
+++ b/resolve_proxy_encoder/queuer/link.py
@@ -5,7 +5,7 @@ import logging
 import os
 from typing import Tuple, Union
 
-from rich import print
+from rich import print as pprint
 from rich.console import Console
 from rich.prompt import Confirm, Prompt
 
@@ -27,7 +27,7 @@ def get_proxy_path():
 
     f = Prompt.ask("Enter path to search for proxies")
     if f is None:
-        print("User cancelled. Exiting.")
+        pprint("User cancelled. Exiting.")
         core.app_exit(0, 0)
     return f
 
@@ -40,14 +40,14 @@ def recurse_dir(root):
     all_files = [
         os.path.join(root, f) for root, dirs, files in os.walk(root) for f in files
     ]
-    print(f"Found {len(all_files)} files in folder {root}")
+    pprint(f"Found {len(all_files)} files in folder {root}")
     return all_files
 
 
 def filter_files(dir_, extension_whitelist):
     """Filter files by allowed filetype"""
 
-    # print(f"{timeline.GetName()} - Video track count: {track_len}")
+    # pprint(f"{timeline.GetName()} - Video track count: {track_len}")
     allowed = [x for x in dir_ if os.path.splitext(x) in extension_whitelist]
     return allowed
 
@@ -181,12 +181,12 @@ def find_and_link_proxies(project, proxy_files) -> Tuple[list, list]:
             logger.info(f" -> [yellow]No more clips to link in {timeline_data['name']}")
             continue
         else:
-            print("\n")
+            pprint("\n")
             console.rule(
                 f":mag_right: [cyan bold]Searching timeline '{timeline_data['name']}'",
                 align="left",
             )
-            print("\n")
+            pprint("\n")
 
         unlinked_proxies = [x for x in proxy_files if x not in linked]
         logger.info(f"Unlinked source count: {len(unlinked_source)}")
@@ -196,7 +196,7 @@ def find_and_link_proxies(project, proxy_files) -> Tuple[list, list]:
             logger.info(f"[green]No more proxies to link[/]")
             break
 
-        print()
+        pprint()
 
         # This inter-function nested loop thing is a little dank.
         linked_, failed_ = _link_proxies(proxy_files, clips)
@@ -226,7 +226,7 @@ def link_proxies_with_mpi(media_list, linkable_types: list = ["Offline", "None"]
     """Iterate through media mutated during script call, attempt to link the source media.
     Return all that are not succesfully linked."""
 
-    print(f"[cyan]Linking {len(media_list)} proxies.[/]")
+    pprint(f"[cyan]Linking {len(media_list)} proxies.[/]")
 
     link_success = []
     link_fail = []
@@ -264,14 +264,14 @@ def link_proxies_with_mpi(media_list, linkable_types: list = ["Offline", "None"]
             link_fail.append(media)
 
     if link_success:
-        print(f"[green]Succeeded linking: [/]{len(link_success)}")
+        pprint(f"[green]Succeeded linking: [/]{len(link_success)}")
 
     if link_fail:
-        print(f"[red]Failed linking: [/]{len(link_fail)}")
+        pprint(f"[red]Failed linking: [/]{len(link_fail)}")
 
-    print()
+    pprint()
 
-    print(f"[green]{len(link_success)} proxy(s) successfully linked.")
+    pprint(f"[green]{len(link_success)} proxy(s) successfully linked.")
 
     if link_fail:
 
@@ -284,13 +284,12 @@ def link_proxies_with_mpi(media_list, linkable_types: list = ["Offline", "None"]
                     x["proxy_status"] = "None"
 
             media_list = [x for x in media_list if x not in link_success]
+            return media_list
 
-    else:
-
-        # Queue only those that remain
-        media_list = [
-            x for x in media_list if x not in link_success or x not in link_fail
-        ]
+    # Queue only those that remain
+    media_list = [
+        x for x in media_list if all([x not in link_success, x not in link_fail])
+    ]
 
     logger.debug(f"[magenta]Remaining unlinked media: {media_list}")
     return media_list
@@ -305,7 +304,7 @@ def main():
         r_ = ResolveObjects()
         proxy_dir = get_proxy_path()
 
-        print(f"Passed directory: '{proxy_dir}'\n")
+        pprint(f"Passed directory: '{proxy_dir}'\n")
 
         all_files = recurse_dir(proxy_dir)
         proxy_files = filter_files(
@@ -314,7 +313,7 @@ def main():
         linked = find_and_link_proxies(r_.project, proxy_files)
 
     except Exception as e:
-        print("ERROR - " + str(e))
+        pprint("ERROR - " + str(e))
 
 
 if __name__ == "__main__":

--- a/version_constraint_key
+++ b/version_constraint_key
@@ -1,1 +1,1 @@
-nutty-nightingale
+violet-vulture


### PR DESCRIPTION
Addresses #177

Media that is linked by the `handle_existing_unlinked` handler is now properly removed 
from the media_list before being passed on.

## Changes:
- Fixed broken if/else logic that bypasses list comprehension
- Fixed broken list comprehension that doesn't comprehend anything